### PR TITLE
Add missing dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,17 @@ This package provides the following commands:
 ## Dependencies
 
 On Ubuntu/Debian, the following packages need to be installed:
+- build-essential
+- gettext
 - libarchive-dev
 - libcurl4-openssl-dev
+- libgpme-dev
 - libssl-dev
+- m4
 - pkg-config
 - python3
 - python3-venv
+- wget
 
 On Arch/Manjaro, the following packages need to be installed:
 - base-devel

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package provides the following commands:
 
 On Ubuntu/Debian, the following packages need to be installed:
 - build-essential
-- gettext
+- gettext (optional to add support for other languages than english)
 - libarchive-dev
 - libcurl4-openssl-dev
 - libgpgme-dev

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ On Ubuntu/Debian, the following packages need to be installed:
 - gettext
 - libarchive-dev
 - libcurl4-openssl-dev
-- libgpme-dev
+- libgpgme-dev
 - libssl-dev
 - m4
 - pkg-config

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ On Ubuntu/Debian, the following packages need to be installed:
 - libcurl4-openssl-dev
 - libgpgme-dev
 - libssl-dev
+- m4
 - pkg-config
 - python3
 - python3-venv

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ On Ubuntu/Debian, the following packages need to be installed:
 - libcurl4-openssl-dev
 - libgpgme-dev
 - libssl-dev
-- m4
 - pkg-config
 - python3
 - python3-venv


### PR DESCRIPTION
Most importantly this adds libgpgme-dev, which allows pacman to build support for signed packages. I'll make some pull requests for the different other repositories.

