### PR TITLE
Include libarchive-tools for bsdtar required by psp-makepkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ On Ubuntu/Debian, the following packages need to be installed:
 - build-essential
 - gettext (optional to add support for other languages than english)
 - libarchive-dev
+- libarchive-tools
 - libcurl4-openssl-dev
 - libgpgme-dev
 - libssl-dev


### PR DESCRIPTION
Like the title suggests.

Debian systems will require libarchive-tools which inludes FreeBSD implementations of 'tar' and 'cpio' and other archive tools, required by psp-makepkg to extract tar files.