### PR TITLE
Revert "Add pkgconf options to makepkg.conf"

### DIFF
--- a/config/makepkg.conf
+++ b/config/makepkg.conf
@@ -49,10 +49,6 @@ MAKEFLAGS="-j$(nproc --all)"
 #DEBUG_CFLAGS="-g"
 #DEBUG_CXXFLAGS="-g"
 
-#-- pkgconf configuration
-unset PKG_CONFIG_PATH
-export PKG_CONFIG_LIBDIR="$(psp-config --psp-prefix)/lib/pkgconfig"
-
 #########################################################################
 # BUILD ENVIRONMENT
 #########################################################################


### PR DESCRIPTION
This reverts commit 2ece16371e1dd851769d34ffb41443656a6bd830. I've been told it shouldn't be needed.