### PR TITLE
Add repository

### DIFF
--- a/config/pacman.conf
+++ b/config/pacman.conf
@@ -75,3 +75,7 @@ CheckSpace
 #[custom]
 #SigLevel = Optional TrustAll
 #Server = file:///home/custompkgs
+
+[pspdev]
+SigLevel = Optional TrustAll
+Server = https://github.com/sharkwouter/psplibraries/releases/download/master/

--- a/config/pacman.conf
+++ b/config/pacman.conf
@@ -78,4 +78,4 @@ CheckSpace
 
 [pspdev]
 SigLevel = Optional TrustAll
-Server = https://github.com/sharkwouter/psplibraries/releases/download/master/
+Server = https://github.com/pspdev/psp-packages/releases/download/master/

--- a/config/pacman.conf
+++ b/config/pacman.conf
@@ -78,4 +78,4 @@ CheckSpace
 
 [pspdev]
 SigLevel = Optional TrustAll
-Server = https://github.com/pspdev/psp-packages/releases/download/master/
+Server = https://github.com/pspdev/psp-packages/releases/latest/download/


### PR DESCRIPTION
~~This will work when https://github.com/pspdev/psplibraries/pull/80 has been merged.~~

~~New plan, this will be needed when the psp-packages repo has been transferred to the pspdev organization.~~

In the meantime the psp-packages repo exists and builds succesfully. It's fully up and running. This can be merged safely now.