### PR TITLE
Fix strip in makepkg

### DIFF
--- a/patches/pacman-6.0.1.patch
+++ b/patches/pacman-6.0.1.patch
@@ -65,6 +65,43 @@ index 76b9d2a..673324c 100644
  if os.startswith('darwin')
    inodecmd = '/usr/bin/stat -f \'%i %N\''
    strip_binaries = ''
+diff --git a/scripts/libmakepkg/executable/strip.sh.in b/scripts/libmakepkg/executable/strip.sh.in
+index d4d53b9..5226fce 100644
+--- a/scripts/libmakepkg/executable/strip.sh.in
++++ b/scripts/libmakepkg/executable/strip.sh.in
+@@ -30,8 +30,8 @@ executable_functions+=('executable_strip')
+ 
+ executable_strip() {
+ 	if check_option "strip" "y"; then
+-		if ! type -p strip >/dev/null; then
+-			error "$(gettext "Cannot find the %s binary required for object file stripping.")" "strip"
++		if ! type -p psp-strip >/dev/null; then
++			error "$(gettext "Cannot find the %s binary required for object file stripping.")" "psp-strip"
+ 			return 1
+ 		fi
+ 	fi
+diff --git a/scripts/libmakepkg/tidy/strip.sh.in b/scripts/libmakepkg/tidy/strip.sh.in
+index 9660253..5c52ee0 100644
+--- a/scripts/libmakepkg/tidy/strip.sh.in
++++ b/scripts/libmakepkg/tidy/strip.sh.in
+@@ -97,7 +97,7 @@ strip_file() {
+ 	fi
+ 
+ 	local tempfile=$(mktemp "$binary.XXXXXX")
+-	if strip "$@" "$binary" -o "$tempfile"; then
++	if psp-strip "$@" "$binary" -o "$tempfile"; then
+ 		cat "$tempfile" > "$binary"
+ 	fi
+ 	rm -f "$tempfile"
+@@ -107,7 +107,7 @@ strip_lto() {
+ 	local binary=$1;
+ 
+ 	local tempfile=$(mktemp "$binary.XXXXXX")
+-	if strip -R .gnu.lto_* -R .gnu.debuglto_* -N __gnu_lto_v1 "$binary" -o "$tempfile"; then
++	if psp-strip -R .gnu.lto_* -R .gnu.debuglto_* -N __gnu_lto_v1 "$binary" -o "$tempfile"; then
+ 		cat "$tempfile" > "$binary"
+ 	fi
+ 	rm -f "$tempfile"
 diff --git a/scripts/makepkg.sh.in b/scripts/makepkg.sh.in
 index e58edfa..03a9709 100644
 --- a/scripts/makepkg.sh.in

--- a/scripts/psp-makepkg
+++ b/scripts/psp-makepkg
@@ -15,12 +15,6 @@ fi
 export PACMAN=psp-pacman
 export MAKEPKG_CONF="${PSPDEV}/etc/makepkg.conf"
 
-## Force makepkg to use psp-strip for stripping binaries
-function strip {
-    psp-strip "$@"
-}
-export -f strip
-
 ## Add the directory with pacman's binaries to the start of the PATH
 export PATH="${PSPDEV}/share/pacman/bin:${PATH}"
 


### PR DESCRIPTION
Stripping in the tidy step in the build process when building with makepkg will currently always fail, because the wrong executable is used. This PR addresses that.