### PR TITLE
Add workaround for MacOS build issue

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -48,6 +48,7 @@ jobs:
       if: matrix.os[0] == 'macOS-latest'
       run: |
         brew install gettext texinfo bison flex gnu-sed ncurses gsl gmp mpfr autoconf automake cmake libusb-compat libarchive gpgme bash openssl libtool
+        gsed -i '/Requires.private: iconv/d' /usr/local/opt/libarchive/lib/pkgconfig/libarchive.pc || true
         echo "MSYSTEM=x64" >> $GITHUB_ENV
 
     # - name: Install MSYS2 texinfo bison flex


### PR DESCRIPTION
This is a small workaround that is needed to get the MacOS build to work. See #21 for details. This workaround comes from one of the comments on the issue linked in that issue.