### PR TITLE
A more universal solution, darwin works

### DIFF
--- a/config/makepkg.conf
+++ b/config/makepkg.conf
@@ -44,7 +44,7 @@ CHOST="psp"
 #CXXFLAGS="-O2 -pipe"
 #LDFLAGS=""
 #-- Make Flags: change this for DistCC/SMP systems
-MAKEFLAGS="-j$(nproc --all)"
+MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"
 #-- Debugging flags
 #DEBUG_CFLAGS="-g"
 #DEBUG_CXXFLAGS="-g"


### PR DESCRIPTION
Replace nproc with getconf _NPROCESSORS_ONLN, a more platform agnostic solution