### PR TITLE
disable download timeout

### DIFF
--- a/config/pacman.conf
+++ b/config/pacman.conf
@@ -35,6 +35,7 @@ Architecture = mips
 #TotalDownload
 CheckSpace
 #VerbosePkgLists
+DisableDownloadTimeout
 
 # PGP signature checking
 #SigLevel = Optional


### PR DESCRIPTION
Sometimes internet speed is slow and can cause breakage when installing pspdev from source, this is my fix for that issue