### PR TITLE
Add psptoolchain-extra dispatch

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -62,3 +62,21 @@ jobs:
         export PATH=$PATH:$PSPDEV/bin
         psp-pacman -V
         psp-makepkg -V
+
+  dispatch:
+    if: contains(github.ref,'refs/heads/master')
+    needs: [build, build-VM]
+    runs-on: ubuntu-latest
+  
+    steps:
+    - name: Send Compile action
+      run: |
+        export DISPATCH_ACTION="$(echo run_build)"
+        echo "NEW_DISPATCH_ACTION=$DISPATCH_ACTION" >> $GITHUB_ENV
+    - name: Repository Dispatch to psptoolchain-extra
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        repository: ${{ github.repository_owner }}/psptoolchain-extra
+        token: ${{ secrets.DISPATCH_TOKEN }}
+        event-type: ${{ env.NEW_DISPATCH_ACTION }}
+        client-payload: '{"ref": "${{ github.ref }}"}'


### PR DESCRIPTION
Right now this is missing. I'm not sure if this would require us to still set some variables in the github runner settings or if they are already set.