### PR TITLE
Fix MacOS build

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -54,9 +54,9 @@ jobs:
 
     - name: Compile Tools
       run: |
-        export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
-        export PATH="/usr/local/opt/libtool/libexec/gnubin:$PATH"
-        export PKG_CONFIG_PATH="/usr/local/opt/libarchive/lib/pkgconfig:/usr/local/opt/openssl@3/lib/pkgconfig"
+        export PATH="$(brew --prefix gnu-sed)/libexec/gnubin:$PATH" # This really is only needed for macOS
+        export PATH="$(brew --prefix libtool)/libexec/gnubin:$PATH" # This really is only needed for macOS
+        export PKG_CONFIG_PATH="$(brew --prefix libarchive)/lib/pkgconfig:$(brew --prefix openssl)/lib/pkgconfig" #This really is only needed for macOS
         export PSPDEV=$PWD/pspdev
         ./pacman.sh
         export PATH=$PATH:$PSPDEV/bin


### PR DESCRIPTION
Right now the MacOS build is failing because the macos-latest runner was upgraded to a new version and hardware. This should fix that.