### PR TITLE
Remove venv usage when installing psp-pacman

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -47,10 +47,3 @@ function download_and_extract
 function apply_patch {
     patch -p1 < "${BASE_PATH}/patches/$1.patch"
 }
-
-## Install meson and ninja in the current directory using a venv
-function setup_build_system {
-    python3 -m venv venv
-    . venv/bin/activate
-    pip install meson ninja
-}

--- a/pacman.sh
+++ b/pacman.sh
@@ -34,9 +34,6 @@ find ./ -type f -name "*.in" -exec sed -i -e 's#@libmakepkgdir@#${PSPDEV}/share/
 ## Apply patch
 apply_patch pacman-${PACMAN_VERSION}
 
-## Install meson and ninja in the current directory
-setup_build_system
-
 ## Build pacman
 meson build -Dprefix="${PSPDEV}" --buildtype=release \
   -Ddefault_library=static  -Dbuildscript=PSPBUILD \


### PR DESCRIPTION
I want to propose this PR to totally remove the usage of virtual environment of pacman installation. I think there's no potential issue with their installed packages and nowadays the installation of python's packages are via package manager instead of pip. 