### PR TITLE
Fix buffer overflow when running -Qi in Ubuntu 25.10

### DIFF
--- a/pacman.sh
+++ b/pacman.sh
@@ -33,6 +33,7 @@ find ./ -type f -name "*.in" -exec sed -i -e 's#@libmakepkgdir@#${PSPDEV}/share/
 
 ## Apply patch
 apply_patch pacman-${PACMAN_VERSION}
+apply_patch 147
 
 ## Install meson and ninja in the current directory
 setup_build_system

--- a/pacman.sh
+++ b/pacman.sh
@@ -33,7 +33,7 @@ find ./ -type f -name "*.in" -exec sed -i -e 's#@libmakepkgdir@#${PSPDEV}/share/
 
 ## Apply patch
 apply_patch pacman-${PACMAN_VERSION}
-apply_patch 147
+apply_patch 147 # Fixes https://github.com/pspdev/psp-pacman/issues/37
 
 ## Install meson and ninja in the current directory
 setup_build_system

--- a/patches/147.patch
+++ b/patches/147.patch
@@ -1,0 +1,35 @@
+From 5e0496260b7d3f9c9fcf2b1c4899e4dbcc20ff03 Mon Sep 17 00:00:00 2001
+From: Ivan Shapovalov <intelfx@intelfx.name>
+Date: Wed, 13 Mar 2024 04:27:31 +0100
+Subject: [PATCH] make_aligned_titles: pass the correct buffer length
+
+The third parameter to wcstombs() is the length of the output buffer
+(first parameter) in bytes. Take the correct sizeof() here.
+
+This is not a problem in practice, but prevents _FORTIFY_SOURCE=3 from
+detecting a possible output buffer overflow (as the source buffer is
+bigger than the destination).
+
+Fixes #104.
+
+Signed-off-by: Ivan Shapovalov <intelfx@intelfx.name>
+---
+ src/pacman/package.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/pacman/package.c b/src/pacman/package.c
+index b832663c0..95d0c4c4c 100644
+--- a/src/pacman/package.c
++++ b/src/pacman/package.c
+@@ -140,7 +140,7 @@ static void make_aligned_titles(void)
+ 		size_t padlen = maxcol - wcol[i];
+ 		wmemset(wbuf[i] + wlen[i], L' ', padlen);
+ 		wmemcpy(wbuf[i] + wlen[i] + padlen, title_suffix, ARRAYSIZE(title_suffix));
+-		wcstombs(titles[i], wbuf[i], sizeof(wbuf[i]));
++		wcstombs(titles[i], wbuf[i], sizeof(titles[i]));
+ 	}
+ }
+ 
+-- 
+GitLab
+


### PR DESCRIPTION
This fixed #37. I reproduced that issue in Docker and I found a fix in the Pacman Gitlab repo. This PR includes the patch from that fix. Source here: https://gitlab.archlinux.org/pacman/pacman/-/merge_requests/147