### PR TITLE
Set arch to build and install dynamically based on OS

### DIFF
--- a/config/makepkg.conf
+++ b/config/makepkg.conf
@@ -35,7 +35,6 @@ AR="psp-ar"
 RANLIB="psp-ranlib"
 CC="psp-gcc"
 CXX="psp-g++"
-CARCH="mips"
 CHOST="psp"
 
 #-- Compiler and Linker Flags

--- a/pacman.sh
+++ b/pacman.sh
@@ -57,6 +57,7 @@ install -m 644 config/makepkg.conf "${PSPDEV}/etc/makepkg.conf"
 install -d "${PSPDEV}/bin/"
 install -m 755 scripts/psp-pacman "${PSPDEV}/bin/psp-pacman"
 install -m 755 scripts/psp-makepkg "${PSPDEV}/bin/psp-makepkg"
+install -D -m 755 scripts/get-arch "${PSPDEV}/share/pacman/bin/get-arch"
 
 ## Make sure the dbpath directory exists
 mkdir -p "${PSPDEV}/var/lib/pacman"

--- a/scripts/get-arch
+++ b/scripts/get-arch
@@ -16,7 +16,7 @@ elif [ "${KERNEL}" == "Linux" ]; then
       OS="fedora"
     ;;
     *)
-      OS="ubuntu"
+      OS="linux"
     ;;
   esac
 else

--- a/scripts/get-arch
+++ b/scripts/get-arch
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+KERNEL="$(uname -s)"
+ARCH="$(uname -m)"
+
+OS=""
+if [ "${KERNEL}" == "Darwin" ]; then
+  OS="macos"
+elif [ "${KERNEL}" == "Linux" ]; then
+  TESTOS=$(cat /etc/os-release | grep -w "ID" | cut -d '=' -f2 | tr -d '"')
+  case $TESTOS in
+    debian)
+      OS="debian"
+    ;;
+    fedora | rhel)
+      OS="fedora"
+    ;;
+    *)
+      OS="ubuntu"
+    ;;
+  esac
+else
+  OS="${KERNEL}"
+fi
+
+echo "${OS}_${ARCH}"

--- a/scripts/psp-makepkg
+++ b/scripts/psp-makepkg
@@ -19,4 +19,4 @@ export MAKEPKG_CONF="${PSPDEV}/etc/makepkg.conf"
 export PATH="${PSPDEV}/share/pacman/bin:${PATH}"
 
 ## Run makepkg
-makepkg "$@"
+CARCH="$(${PSPDEV}/share/pacman/bin/get-arch)"  makepkg "$@"

--- a/scripts/psp-pacman
+++ b/scripts/psp-pacman
@@ -30,4 +30,4 @@ pacman \
   --logfile "${PSPDEV}/var/log/pacman.log" \
   --hookdir "${PSPDEV}/share/libalpm/hooks" \
   --hookdir "${PSPDEV}/etc/pacman.d/hooks" \
-  "$@"
+  --arch "$(${PSPDEV}/share/pacman/bin/get-arch)" "$@"


### PR DESCRIPTION
This is a prerequisite to us shipping the full SDK as Pacman packages. We're expected to ship the following:

- linux_x86_64 (Ubuntu, Windows and any unknown Linux)
- debian_x86_64 (Latest Debian)
- fedora_x86_64 (Fedora and RHEL(?))
- macos_arm64
- macos_x86_64

This does not affect the builds of the packages in psp-packages, since they have the arch set to any.