### PR TITLE
Update get-arch

### DIFF
--- a/scripts/get-arch
+++ b/scripts/get-arch
@@ -18,7 +18,7 @@ elif [ "${KERNEL}" == "Linux" ]; then
     fedora | rhel)
       OS="fedora"
     ;;
-    ubuntu)
+    ubuntu | pop)
       OS="ubuntu"
     ;;
     *)

--- a/scripts/get-arch
+++ b/scripts/get-arch
@@ -18,7 +18,7 @@ elif [ "${KERNEL}" == "Linux" ]; then
     fedora | rhel)
       OS="fedora"
     ;;
-    ubuntu | pop)
+    ubuntu | pop | linuxmint)
       OS="ubuntu"
     ;;
     *)

--- a/scripts/get-arch
+++ b/scripts/get-arch
@@ -9,11 +9,17 @@ if [ "${KERNEL}" == "Darwin" ]; then
 elif [ "${KERNEL}" == "Linux" ]; then
   TESTOS=$(cat /etc/os-release | grep -w "ID" | cut -d '=' -f2 | tr -d '"')
   case $TESTOS in
+    alpine)
+      OS="alpine"
+    ;;
     debian)
       OS="debian"
     ;;
     fedora | rhel)
       OS="fedora"
+    ;;
+    ubuntu)
+      OS="ubuntu"
     ;;
     *)
       OS="linux"


### PR DESCRIPTION
This adds the following architectures:
- ubuntu_arch
- linux_arch (for unknown linux)
- alpine_arch

Right now ubuntu is linux_arch despite it being our main platform along with alpine, which also does not have an own arch without this PR.