### PR TITLE
Use system meson and ninja instead of from a venv

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -20,19 +20,19 @@ jobs:
       if: startsWith(matrix.os, 'debian')
       run: |
         apt-get update
-        apt-get install -y wget adduser build-essential python3 python3-venv pkgconf libcurl4 libcurl4-openssl-dev libssl-dev libarchive-tools libarchive-dev libgpgme-dev git sudo
+        apt-get install -y wget adduser build-essential meson ninja-build pkgconf libcurl4 libcurl4-openssl-dev libssl-dev libarchive-tools libarchive-dev libgpgme-dev git sudo
         adduser --system --group build
 
     - name: Install Alpine build dependencies
       if: startsWith(matrix.os, 'alpine')
       run: |
-        apk add wget wget build-base bash python3 py3-pip pkgconfig libarchive-tools libarchive-dev openssl-dev gpgme-dev curl-dev git sudo fakeroot
+        apk add wget wget build-base bash meson ninja-build pkgconfig libarchive-tools libarchive-dev openssl-dev gpgme-dev curl-dev git sudo fakeroot
         adduser -D -s /bin/bash build
 
     - name: Install Fedora build dependencies
       if: startsWith(matrix.os, 'fedora')
       run: |
-        dnf -y install gcc python3 python3-pip wget bsdtar libarchive-devel openssl-devel gpgme-devel libcurl-devel pkgconf git patch sudo which fakeroot
+        dnf -y install gcc meson ninja-build wget bsdtar libarchive-devel openssl-devel gpgme-devel libcurl-devel pkgconf git patch sudo which fakeroot
         useradd build
 
     - uses: actions/checkout@v6
@@ -85,12 +85,12 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
-        sudo apt-get -y install libcurl4 libcurl4-openssl-dev libssl-dev libarchive-tools libarchive-dev libgpgme-dev sudo
+        sudo apt-get -y install meson libcurl4-openssl-dev libarchive-tools libarchive-dev libgpgme-dev
 
     - name: Install Mac build dependencies
       if: startsWith(matrix.os, 'macos')
       run: |
-        brew install bash gnu-sed libarchive gpgme fakeroot
+        brew install bash meson gnu-sed libarchive gpgme fakeroot
 
     - name: Compile Tools
       run: |

--- a/common.sh
+++ b/common.sh
@@ -47,10 +47,3 @@ function download_and_extract
 function apply_patch {
     patch -p1 < "${BASE_PATH}/patches/$1.patch"
 }
-
-## Install meson and ninja in the current directory using a venv
-function setup_build_system {
-    python3 -m venv venv
-    . venv/bin/activate
-    pip install meson ninja
-}

--- a/pacman.sh
+++ b/pacman.sh
@@ -36,9 +36,6 @@ find ./ -type f -name "*.in" -exec sed -i -e "s#export TEXTDOMAINDIR='@localedir
 find ./ -type f -name "*.in" -exec sed -i -e "s#'@libmakepkgdir@'#\${PSPDEV}/share/makepkg#g" {} \;
 find ./ -type f -name "*.in" -exec sed -i -e "s#@libmakepkgdir@#\${PSPDEV}/share/makepkg#g" {} \;
 
-## Install meson and ninja in the current directory
-setup_build_system
-
 ## Build pacman
 meson build -Dprefix="${PSPDEV}" --buildtype=release \
   -Ddefault_library=static  -Dbuildscript=PSPBUILD \


### PR DESCRIPTION
The python venv setup was necessary in the past for much older operating systems, but today the version of meson on the oldest system we support can build pacman just fine. This means we can remove this ugly workaround.