### PR TITLE
Fix artifact names to include platform

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -55,7 +55,6 @@ jobs:
         ARCH="$(./get-arch)"
         echo "ARCH=${ARCH}" >> $GITHUB_ENV
         tar -czvf pspdev-${ARCH}.tar.gz pspdev
-        ls -l
 
     - uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -52,8 +52,9 @@ jobs:
 
     - name: Create archive
       run: |
-        echo "ARCH=$(./get-arch)" >> $GITHUB_ENV
-        tar -czvf pspdev-${{ env.ARCH }}.tar.gz pspdev
+        ARCH="$(./get-arch)"
+        echo "ARCH=${ARCH}" >> $GITHUB_ENV
+        tar -czvf pspdev-${ARCH}.tar.gz pspdev
         ls -l
 
     - uses: actions/upload-artifact@v7


### PR DESCRIPTION
I found out at the archives that contain the installed psp-pacman version are all called pspdev-.tar.gz, because I'm relying on a variable that is not yet available at the point of making the archive. This addresses this issue. We need this for single command install to work later.